### PR TITLE
feat: Update file renaming and add JSON output for object detection

### DIFF
--- a/tests/test_import_dataset.py
+++ b/tests/test_import_dataset.py
@@ -1,14 +1,11 @@
 import json
+import random
+import sys
 from pathlib import Path
 
 import pytest
-
-from PIL import Image
-
-import random
-
-import sys
 import yaml
+from PIL import Image
 
 from trailcam_classifier.import_dataset import (
     _discover_images,
@@ -172,9 +169,7 @@ def test_convert_bbox_to_yolo():
     img_width = 1920
     img_height = 1080
     bbox = {"x1": 480, "y1": 270, "x2": 1440, "y2": 810}
-    x_center_norm, y_center_norm, width_norm, height_norm = convert_bbox_to_yolo(
-        img_width, img_height, bbox
-    )
+    x_center_norm, y_center_norm, width_norm, height_norm = convert_bbox_to_yolo(img_width, img_height, bbox)
     assert x_center_norm == pytest.approx(0.5)
     assert y_center_norm == pytest.approx(0.5)
     assert width_norm == pytest.approx(0.5)


### PR DESCRIPTION
This commit updates the script to support object detection.

The main changes are:
- File renaming logic is updated to include all detected objects and their counts in the filename. The format is `<original_filename>_<object_count><class_name>_...`, with class names sorted alphabetically.
- A companion JSON file is now created for each image with detected objects. This file contains the bounding boxes for each detected object.
- If no objects are detected, no JSON file is created.
- The `--print-only` option now prints the JSON content to the console instead of writing it to a file.
- Removed obsolete command-line arguments and configuration options related to the old image classification behavior.