### PR TITLE
Add a utility script to remove duplicate images.

### DIFF
--- a/tests/test_remove_duplicates.py
+++ b/tests/test_remove_duplicates.py
@@ -1,0 +1,74 @@
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def temp_dir_with_images():
+    test_dir = tempfile.mkdtemp()
+    subdir = Path(test_dir) / "subdir"
+    subdir.mkdir()
+
+    image1_path = Path(test_dir) / "image1.jpg"
+    image2_path = Path(test_dir) / "image2.jpg"
+    image3_path = Path(test_dir) / "image3.jpg"
+    image4_path = subdir / "image4.jpg"
+    text_file_path = Path(test_dir) / "notes.txt"
+
+    image1_path.write_bytes(b"image data 1")
+    image2_path.write_bytes(b"image data 2")
+    image3_path.write_bytes(b"image data 1")
+    image4_path.write_bytes(b"image data 1")
+    text_file_path.write_text("this is not an image")
+
+    yield test_dir, image1_path, image2_path, image3_path, image4_path, text_file_path
+
+    shutil.rmtree(test_dir)
+
+
+def test_remove_duplicates_script(temp_dir_with_images):
+    test_dir, image1_path, image2_path, image3_path, image4_path, text_file_path = temp_dir_with_images
+    script_path = Path(__file__).parent.parent / "utils" / "remove_duplicates.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), test_dir],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"Script failed with output:\n{result.stdout}\n{result.stderr}"
+
+    assert image1_path.exists()
+    assert image2_path.exists()
+    assert not image3_path.exists()
+    assert not image4_path.exists()
+    assert text_file_path.exists()
+
+
+def test_remove_duplicates_script_dry_run(temp_dir_with_images):
+    test_dir, image1_path, image2_path, image3_path, image4_path, text_file_path = temp_dir_with_images
+    script_path = Path(__file__).parent.parent / "utils" / "remove_duplicates.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script_path), test_dir, "--dry-run"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"Script failed with output:\n{result.stdout}\n{result.stderr}"
+
+    assert f"Duplicate found: {image3_path} is a duplicate of {image1_path} (would be deleted)" in result.stdout
+    assert f"Duplicate found: {image4_path} is a duplicate of {image1_path} (would be deleted)" in result.stdout
+    assert "Found 2 duplicate images that would be removed." in result.stdout
+
+    assert image1_path.exists()
+    assert image2_path.exists()
+    assert image3_path.exists()
+    assert image4_path.exists()
+    assert text_file_path.exists()

--- a/utils/remove_duplicates.py
+++ b/utils/remove_duplicates.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import os
+from pathlib import Path
+
+# ruff: noqa: T201 `print` found
+
+DEFAULT_IMAGE_EXTENSIONS = {"jpg", "jpeg"}
+
+
+def find_images(
+    input_dirs: list[str], ignore_dirs: list[str] | None = None, extensions: set[str] | None = None
+) -> set[Path]:
+    """Recursively finds all images in the given input_dirs."""
+    if not extensions:
+        extensions = DEFAULT_IMAGE_EXTENSIONS
+
+    input_dirs = [Path(os.path.expanduser(input_dir)) for input_dir in input_dirs]
+
+    combined_results = itertools.chain.from_iterable(base_path.rglob("*.*") for base_path in input_dirs)
+    all_files = set(combined_results)
+
+    if ignore_dirs is None:
+        ignore_dirs = []
+    ignored_paths = [Path(ignored) for ignored in ignore_dirs]
+
+    def keep_file(filename: Path) -> bool:
+        if any(filename.is_relative_to(ignored) for ignored in ignored_paths):
+            return False
+
+        if not filename.is_file():
+            return False
+
+        return filename.suffix[1:].lower() in extensions
+
+    return {filename for filename in all_files if keep_file(filename)}
+
+
+def hash_file(path: Path) -> str:
+    """Calculates the SHA256 hash of a file."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(h.block_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def remove_duplicate_images(directory: str, *, dry_run: bool = False):
+    """
+    Recursively finds and removes duplicate images in a directory.
+
+    Duplicates are identified by having the same file size and hash.
+    """
+    if dry_run:
+        print("Dry run mode enabled. No files will be deleted.")
+    print(f"Scanning for duplicate images in {directory}...")
+    images = find_images([directory])
+    hashes: dict[tuple[int, str], Path] = {}
+    duplicates_found = 0
+
+    for image_path in sorted(images):
+        try:
+            file_size = image_path.stat().st_size
+            file_hash = hash_file(image_path)
+            key = (file_size, file_hash)
+
+            if key in hashes:
+                if dry_run:
+                    print(f"Duplicate found: {image_path} is a duplicate of {hashes[key]} (would be deleted)")
+                else:
+                    print(f"Duplicate found: {image_path} is a duplicate of {hashes[key]}")
+                    image_path.unlink()
+                duplicates_found += 1
+            else:
+                hashes[key] = image_path
+        except FileNotFoundError:
+            # This can happen if a file is deleted during the process
+            # (e.g. it was a duplicate of another file that was processed earlier)
+            pass
+    if dry_run:
+        print(f"Scan complete. Found {duplicates_found} duplicate images that would be removed.")
+    else:
+        print(f"Scan complete. Found and removed {duplicates_found} duplicate images.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Recursively find and remove duplicate images in a directory.")
+    parser.add_argument(
+        "directory",
+        type=str,
+        help="The directory to scan for duplicate images.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the files that would be deleted, but do not delete them.",
+    )
+    args = parser.parse_args()
+
+    remove_duplicate_images(args.directory, dry_run=args.dry_run)

--- a/utils/rename_with_exif.py
+++ b/utils/rename_with_exif.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from __future__ import annotations
 
 import itertools


### PR DESCRIPTION
This commit introduces a new utility script `utils/remove_duplicates.py` that recursively searches a directory for images and removes any duplicates.

Features:
- Images are considered duplicates if they have the same file size and the same SHA256 hash.
- The script can be run from the command line and accepts a directory path as an argument.
- A `--dry-run` option is available to print the files that would be deleted without actually deleting them.

The commit also includes a comprehensive test suite for the new script, ensuring its correctness and robustness. The tests cover both the file deletion and the dry-run functionality.